### PR TITLE
Suppress "ReplaceInFile" temporary topfind.old

### DIFF
--- a/install.nsi
+++ b/install.nsi
@@ -238,6 +238,7 @@ Section "OCaml" SecOCaml
   ${StrRep} $0 "$INSTDIR" "\" "\\"
   ; Replace the template with the right directory
   !insertmacro _ReplaceInFile "$INSTDIR\lib\topfind" "@SITELIB@" "$0/lib/site-lib"
+  Delete "$INSTDIR\lib\topfind.old"
 
   Delete "$INSTDIR\etc\findlib.conf"
   FileOpen  $1 "$INSTDIR\etc\findlib.conf" w


### PR DESCRIPTION
Allow a full uninstall if OCaml/ directory was not added any other file.
